### PR TITLE
MOP Cleanup

### DIFF
--- a/src/interface.lisp
+++ b/src/interface.lisp
@@ -5,7 +5,7 @@
                 :make-keyword
                 :get-class-slot)
   (:import-from :crane.meta
-                :table-class
+                :<table-class>
                 :table-name
                 :db
                 :col-foreign)
@@ -34,7 +34,7 @@
  database records in an object-oriented way."))
 (in-package :crane.interface)
 
-(defmethod drop-table ((table table-class))
+(defmethod drop-table ((table <table-class>))
   (query (sxql:drop-table (table-name table))
          (db table)))
 
@@ -112,7 +112,7 @@ happens here."
       (db (class-of obj))))
 
 
-(defmethod clean-tuple ((table table-class) tuple)
+(defmethod clean-tuple ((table <table-class>) tuple)
   "Process a plist returned by CL-DBI into a format that can be accepted by
 make-instance. Inflation happens here."
   (flet ((process-key (key)
@@ -125,7 +125,7 @@ make-instance. Inflation happens here."
                   (type (crane.meta:col-type slot)))
              (list processed-key (inflate value type)))))))
 
-(defmethod plist->object ((table table-class) tuple)
+(defmethod plist->object ((table <table-class>) tuple)
   "Convert a tuple produced by CL-DBI to a CLOS instance."
   (apply #'make-instance (cons table (clean-tuple table tuple))))
 

--- a/src/meta.lisp
+++ b/src/meta.lisp
@@ -4,7 +4,7 @@
   (:import-from :crane.connect
                 :database-type
                 :get-db)
-  (:export :table-class
+  (:export :<table-class>
            :table-name
            :abstractp
            :deferredp
@@ -22,32 +22,34 @@
   (:documentation "This file defines the metaclasses that map CLOS objects to SQL tables, and some basic operations on them."))
 (in-package :crane.meta)
 
-(defclass table-class (closer-mop:standard-class)
+(defclass <table-class> (closer-mop:standard-class)
   ((table-name :reader table-class-name :initarg :table-name)
    (abstractp :reader table-class-abstract-p :initarg :abstractp :initform (list nil))
    (deferredp :reader table-class-deferred-p :initarg :deferredp :initform (list nil))
    (db :reader table-class-db :initarg :db :initform (list crane.connect:*default-db*))))
 
-(defmethod table-name ((class table-class))
+(defmethod table-name ((class <table-class>))
   (if (slot-boundp class 'table-name)
       (car (table-class-name class))
       (class-name class)))
 
-(defmethod abstractp ((class table-class))
+(defmethod abstractp ((class <table-class>))
   (car (table-class-abstract-p class)))
 
-(defmethod deferredp ((class table-class))
+(defmethod deferredp ((class <table-class>))
   (car (table-class-deferred-p class)))
 
-(defmethod db ((class table-class))
+(defmethod db ((class <table-class>))
   (aif (car (table-class-db class))
        it
        crane.connect:*default-db*))
 
-(defmethod closer-mop:validate-superclass ((class table-class) (super closer-mop:standard-class))
+(defmethod closer-mop:validate-superclass ((class <table-class>)
+                                           (super closer-mop:standard-class))
   t)
 
-(defmethod closer-mop:validate-superclass ((class standard-class) (super table-class))
+(defmethod closer-mop:validate-superclass ((class standard-class)
+                                           (super <table-class>))
   t)
 
 (defclass table-class-direct-slot-definition (closer-mop:standard-direct-slot-definition)
@@ -98,15 +100,16 @@
 ;;; the MOP while trying not to end up in r/badcode, like a child
 ;;; playing in the surf...
 
-(defmethod closer-mop:direct-slot-definition-class ((class table-class) &rest initargs)
+(defmethod closer-mop:direct-slot-definition-class ((class <table-class>) &rest initargs)
   (declare (ignore class initargs))
   (find-class 'table-class-direct-slot-definition))
 
-(defmethod closer-mop:effective-slot-definition-class ((class table-class) &rest initargs)
+(defmethod closer-mop:effective-slot-definition-class ((class <table-class>) &rest initargs)
   (declare (ignore class initargs))
   (find-class 'table-class-effective-slot-definition))
 
-(defmethod closer-mop:compute-effective-slot-definition ((class table-class) slot-name direct-slot-definitions)
+(defmethod closer-mop:compute-effective-slot-definition ((class <table-class>)
+                                                         slot-name direct-slot-definitions)
   (declare (ignore slot-name))
   (let ((effective-slot-definition (call-next-method)))
     (setf (slot-value effective-slot-definition 'col-type)
@@ -152,7 +155,7 @@
         :autoincrementp (col-autoincrement-p slot)
         :foreign (col-foreign slot)))
 
-(defmethod digest ((class table-class))
+(defmethod digest ((class <table-class>))
   "Serialize a class's options and slots' options into a plist"
   (list :table-options
         (list :db (db class))

--- a/src/meta.lisp
+++ b/src/meta.lisp
@@ -31,15 +31,21 @@
               :initarg :deferredp
               :initform (list nil)
               :documentation "Whether the class should be built only when explicitly calling build.")
-   (database :reader table-database
+   (database :reader %table-database
              :initarg :database
-             :initform (list crane.connect:*default-db*)
+             :initform nil
              :documentation "The database this class belongs to."))
   (:documentation "A table metaclass."))
 
 (defmethod table-name ((class <table-class>))
   "Return the name of a the class, a symbol."
   (class-name class))
+
+(defmethod table-database ((class <table-class>))
+  "The database this class belongs to."
+  (aif (%table-database class)
+       it
+       crane.connect:*default-db*))
 
 (defmethod closer-mop:validate-superclass ((class <table-class>)
                                            (super closer-mop:standard-class))

--- a/src/meta.lisp
+++ b/src/meta.lisp
@@ -23,21 +23,35 @@
 (in-package :crane.meta)
 
 (defclass <table-class> (closer-mop:standard-class)
-  ((abstractp :reader table-class-abstract-p :initarg :abstractp :initform (list nil))
-   (deferredp :reader table-class-deferred-p :initarg :deferredp :initform (list nil))
-   (db :reader table-class-db :initarg :db :initform (list crane.connect:*default-db*))))
+  ((abstractp :reader table-class-abstract-p
+              :initarg :abstractp
+              :initform (list nil)
+              :documentation "Whether the class corresponds to an SQL table or not.")
+   (deferredp :reader table-class-deferred-p
+              :initarg :deferredp
+              :initform (list nil)
+              :documentation "Whether the class should be built only when explicitly calling build.")
+   (database :reader table-class-database
+             :initarg :database
+             :initform (list crane.connect:*default-db*)
+             :documentation "The database this class belongs to."))
+  (:documentation "A table metaclass."))
 
 (defmethod table-name ((class <table-class>))
+  "The name of the table, a symbol that can be used with SxQL."
   (class-name class))
 
 (defmethod abstractp ((class <table-class>))
+  "Whether the table is abstract or not."
   (car (table-class-abstract-p class)))
 
 (defmethod deferredp ((class <table-class>))
+  "Whether construction of the table is deferred or not."
   (car (table-class-deferred-p class)))
 
 (defmethod db ((class <table-class>))
-  (aif (car (table-class-db class))
+  "The database this table is stored in."
+  (aif (car (table-class-database class))
        it
        crane.connect:*default-db*))
 

--- a/src/meta.lisp
+++ b/src/meta.lisp
@@ -23,15 +23,12 @@
 (in-package :crane.meta)
 
 (defclass <table-class> (closer-mop:standard-class)
-  ((table-name :reader table-class-name :initarg :table-name)
-   (abstractp :reader table-class-abstract-p :initarg :abstractp :initform (list nil))
+  ((abstractp :reader table-class-abstract-p :initarg :abstractp :initform (list nil))
    (deferredp :reader table-class-deferred-p :initarg :deferredp :initform (list nil))
    (db :reader table-class-db :initarg :db :initform (list crane.connect:*default-db*))))
 
 (defmethod table-name ((class <table-class>))
-  (if (slot-boundp class 'table-name)
-      (car (table-class-name class))
-      (class-name class)))
+  (class-name class))
 
 (defmethod abstractp ((class <table-class>))
   (car (table-class-abstract-p class)))

--- a/src/meta.lisp
+++ b/src/meta.lisp
@@ -33,28 +33,16 @@
       (car (table-class-name class))
       (class-name class)))
 
-(defmethod table-name ((class-name symbol))
-  (table-name (find-class class-name)))
-
 (defmethod abstractp ((class table-class))
   (car (table-class-abstract-p class)))
 
-(defmethod abstractp ((class-name symbol))
-  (abstractp (find-class class-name)))
-
 (defmethod deferredp ((class table-class))
   (car (table-class-deferred-p class)))
-
-(defmethod deferredp ((class-name symbol))
-  (deferredp (find-class class-name)))
 
 (defmethod db ((class table-class))
   (aif (car (table-class-db class))
        it
        crane.connect:*default-db*))
-
-(defmethod db ((class-name symbol))
-  (db (find-class class-name)))
 
 (defmethod closer-mop:validate-superclass ((class table-class) (super closer-mop:standard-class))
   t)
@@ -176,9 +164,6 @@
               (error 'crane.errors:empty-table
                      :text "The table ~A has no slots."
                      (table-name class))))))
-
-(defmethod digest ((class-name symbol))
-  (digest (find-class class-name)))
 
 (defun diff-slot (slot-a slot-b)
   "Compute the difference between two slot digests.

--- a/src/meta.lisp
+++ b/src/meta.lisp
@@ -25,11 +25,11 @@
 (defclass <table-class> (closer-mop:standard-class)
   ((abstractp :reader abstractp
               :initarg :abstractp
-              :initform (list nil)
+              :initform nil
               :documentation "Whether the class corresponds to an SQL table or not.")
    (deferredp :reader deferredp
               :initarg :deferredp
-              :initform (list nil)
+              :initform nil
               :documentation "Whether the class should be built only when explicitly calling build.")
    (database :reader %table-database
              :initarg :database

--- a/src/migration.lisp
+++ b/src/migration.lisp
@@ -85,7 +85,7 @@ table `table-name`."
   (let* ((constraints (crane.sql:create-and-sort-constraints
                        table-name
                        digest
-                       (crane.meta:db table-name)))
+                       (crane.meta:table-database (find-class table-name))))
          (query
            (format nil +create-table-format-string+
                    (crane.sql:sqlize (table-name (find-class table-name)))
@@ -93,7 +93,8 @@ table `table-name`."
                    (if (getf constraints :internal) "," "")
                    (getf constraints :internal)
                    (getf constraints :external)))
-         (conn (crane.connect:get-connection (crane.meta:db table-name))))
+         (conn (crane.connect:get-connection (crane.meta:table-database
+                                              (find-class table-name)))))
     (format t "~&Query: ~A~&" query)
     (dbi:execute (dbi:prepare conn query))))
 
@@ -114,7 +115,8 @@ table `table-name`."
                        (crane.sql:define-column
                            table-name
                            column
-                           (crane.meta:db table-name)))
+                         (crane.meta:table-database
+                          (find-class table-name))))
                    (getf diff :additions)))
          (additions
            (iter (for def in new-columns)

--- a/src/migration.lisp
+++ b/src/migration.lisp
@@ -141,7 +141,7 @@ table `table-name`."
             (append alterations additions deletions))))
 
 (defun build (table-name)
-  (unless (crane.meta:abstractp table-name)
+  (unless (crane.meta:abstractp (find-class table-name))
     (if (migration-history-p table-name)
         (let ((diff (diff-digest
                      (get-last-migration table-name)

--- a/src/migration.lisp
+++ b/src/migration.lisp
@@ -125,13 +125,11 @@ table `table-name`."
                      (mapcar #'(lambda (internal-constraint)
                                  (crane.sql:add-constraint
                                   table-name
-                                  (getf def :name)
                                   internal-constraint))
                              (getf def :internal))
                      (mapcar #'(lambda (external-constraint)
                                  (crane.sql:add-constraint
                                   table-name
-                                  (getf def :name)
                                   external-constraint))
                              (getf def :external)))))))
          (deletions

--- a/src/migration.lisp
+++ b/src/migration.lisp
@@ -145,7 +145,7 @@ table `table-name`."
     (if (migration-history-p table-name)
         (let ((diff (diff-digest
                      (get-last-migration table-name)
-                     (digest table-name))))
+                     (digest (find-class table-name)))))
           (if (or (getf diff :additions)
                   (getf diff :deletions)
                   (getf diff :changes))
@@ -154,8 +154,8 @@ table `table-name`."
                   (format t "~&Diff for '~A': ~A~&" table-name diff))
                 (migrate (find-class table-name) diff)
                 (insert-migration table-name
-                                  (digest table-name)))))
-        (let ((digest (digest table-name)))
+                                  (digest (find-class table-name))))))
+        (let ((digest (digest (find-class table-name))))
           (insert-migration table-name digest)
           (create-table table-name digest)))))
 

--- a/src/query.lisp
+++ b/src/query.lisp
@@ -2,7 +2,7 @@
   (:use :cl :anaphora :iter)
   (:import-from :crane.meta
                 :table-name
-                :db)
+                :table-database)
   (:import-from :crane.config
                 :debugp)
   (:export :meta-query

--- a/src/sql.lisp
+++ b/src/sql.lisp
@@ -168,7 +168,7 @@ database it's table belongs to"
 
 ;;;; Alter Table
 
-(defun add-constraint (table-name column-name body)
+(defun add-constraint (table-name body)
   "SQL to add a constraint to a table."
   (format nil "ALTER TABLE ~A ADD ~A"
           (sqlize table-name)
@@ -186,9 +186,7 @@ database it's table belongs to"
       (if value
           ;; The constraint wasn't there, add it
           (aif (make-constraint table-name column-name type t)
-               (add-constraint table-name
-                               column-name
-                               it))
+               (add-constraint table-name it))
           ;; The constraint has been dropped
           (drop-constraint table-name
                            column-name
@@ -197,9 +195,7 @@ database it's table belongs to"
       (if value
           ;; Set null
           (aif (make-constraint table-name column-name :nullp t)
-               (add-constraint table-name
-                               column-name
-                               it))
+               (add-constraint table-name it))
           ;; Remove null constraint
           (drop-constraint table-name
                            column-name

--- a/src/table.lisp
+++ b/src/table.lisp
@@ -82,5 +82,5 @@ symbols, table options are keywords."
          ,@options
          (:metaclass crane.meta:<table-class>))
        (closer-mop:finalize-inheritance (find-class ',name))
-       (unless (crane.meta:deferredp ',name)
+       (unless (crane.meta:deferredp (find-class ',name))
          (crane.migration:build ',name)))))

--- a/src/table.lisp
+++ b/src/table.lisp
@@ -56,7 +56,9 @@ symbols, table options are keywords."
   (:metaclass crane.meta:<table-class>))
 
 (defun any-concrete-superclasses (superclasses)
-  (remove-if #'crane.meta:abstractp superclasses))
+  (remove-if #'(lambda (class-name)
+                 (crane.meta:abstractp (find-class class-name)))
+             superclasses))
 
 (defmacro deftable (name (&rest superclasses) &rest slots-and-options)
   "Define a table."

--- a/src/table.lisp
+++ b/src/table.lisp
@@ -53,7 +53,7 @@ symbols, table options are keywords."
     (list slots options)))
 
 (defclass <table> () ()
-  (:metaclass crane.meta:table-class))
+  (:metaclass crane.meta:<table-class>))
 
 (defun any-concrete-superclasses (superclasses)
   (remove-if #'crane.meta:abstractp superclasses))
@@ -80,7 +80,7 @@ symbols, table options are keywords."
                   :initarg :id)))
            slots)
          ,@options
-         (:metaclass crane.meta:table-class))
+         (:metaclass crane.meta:<table-class>))
        (closer-mop:finalize-inheritance (find-class ',name))
        (unless (crane.meta:deferredp ',name)
          (crane.migration:build ',name)))))

--- a/t/postgres/table.lisp
+++ b/t/postgres/table.lisp
@@ -17,15 +17,13 @@
 (test create-another-table
   (finishes
     (deftable table-c (table-a)
-      (field-b :type integer :nullp nil)
-      (:table-name table--c))))
+      (field-b :type integer :nullp nil))))
 
 (test find-tables
   (finishes
     (find-class 'table-a)
     (find-class 'table-b)
     (find-class 'table-c)))
-
 
 (def-suite column-slots
   :description "Test that table column options work.")


### PR DESCRIPTION
Some methods take both a class instance and the name of the class. We want to clean those up so they only take the class instance.