### PR TITLE
Fixed "Tried to call VALUE-LIST on a dotted pair.".

### DIFF
--- a/src/sql.lisp
+++ b/src/sql.lisp
@@ -99,7 +99,7 @@ doesn't create a constraint, but :nullp nil creates a NOT NULL constraint)."
              (:primaryp
               (set-primary column-name value))
              (:foreign
-              (when value (apply #'foreign (cons column-name value)))))
+              (when value (funcall #'foreign column-name value))))
            (concatenate 'string
                         "CONSTRAINT "
                         (constraint-name table-name column-name type)


### PR DESCRIPTION
I just tried 

```lisp
(crane:deftable data-list ()
  (size :type integer))
```

```lisp
(crane:deftable list-elem ()
  (list-id :type integer
	   :foreign data-list)
  (datum :type text)
```

And I was getting the error ```Tried to call VALUE-LIST on a dotted pair.```.
So here is my fix.