### PR TITLE
Make foreign key definitions work

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ relational databases, and out of the box migrations.
 ```lisp
 (deftable user ()
   (name :type text :uniquep t)
-  (age :type integer :nullp nil :initform 18))
+  (age :type integer :nullp nil :initform 18)
+  (friend :type integer :foreign user)))
 ```
+The foreign argument accepts a symbol that represents another table or a sexp of the form `(table &key on-delete on-update))`, where acceptable values are `:no-action :restrict :cascade :set-null :set-default`.
 
 ## Migrating
 

--- a/src/sql.lisp
+++ b/src/sql.lisp
@@ -99,7 +99,7 @@ doesn't create a constraint, but :nullp nil creates a NOT NULL constraint)."
              (:primaryp
               (set-primary column-name value))
              (:foreign
-              (when value (apply #'foreign (cons column-name value)))))
+              (when value (apply #'foreign (cons column-name (if (listp value) value (list value)))))))
            (concatenate 'string
                         "CONSTRAINT "
                         (constraint-name table-name column-name type)
@@ -185,7 +185,7 @@ database it's table belongs to"
   (if (member type (list :primaryp :uniquep :indexp :foreign :check))
       (if value
           ;; The constraint wasn't there, add it
-          (aif (make-constraint table-name column-name type t)
+          (aif (make-constraint table-name column-name type value)
                (add-constraint table-name it))
           ;; The constraint has been dropped
           (drop-constraint table-name


### PR DESCRIPTION
I'm not sure how foreign key definitions were supposed to work, but this makes them work at all for me and I think follows the intention of the code.

I like the `(cons ...)` in `apply` to destructure the argument list. Neat trick!