### PR TITLE
Deflate timestamps to UTC instead of local zone.

### DIFF
--- a/src/inflate-deflate.lisp
+++ b/src/inflate-deflate.lisp
@@ -47,4 +47,4 @@ represent time, or mapping other more complex SQL types to CLOS objects."))
         (local-time:parse-timestring stamp)))
 
 (defdeflate (stamp local-time:timestamp)
-    (local-time:format-timestring nil stamp))
+    (local-time:format-timestring nil stamp :timezone local-time:+utc-zone+))


### PR DESCRIPTION
Postgres columns are 'without time zone'. Inflation takes timezone into account but deflation doesn't. This causes timestamps to change every time a record is saved.