### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ environments, you might want to use [Envy](https://github.com/fukamachi/envy).
 
 ```lisp
 (let ((instance (create 'ship :name "Dalliance"
-                              :tonnage "77")))
+                              :tonnage 77)))
   ;; FIXME: It's back luck to rename a ship
   (setf (name instance) "Serenity")
   ;; Expand the cargo hold


### PR DESCRIPTION
this line causes error:

```lisp
Argument X is not a NUMBER: "77"
   [Condition of type SIMPLE-TYPE-ERROR]
Backtrace:
  0: (SB-KERNEL:TWO-ARG-+ "77" 25)
  1: ((LAMBDA ()))
  2: (SB-INT:SIMPLE-EVAL-IN-LEXENV (LET ((INSTANCE #)) (SETF (NAME INSTANCE) "Serenity") (INCF (TONNAGE INSTANCE) 25) (SAVE INSTANCE)) #<NULL-LEXENV>)
  3: (EVAL (LET ((INSTANCE #)) (SETF (NAME INSTANCE) "Serenity") (INCF (TONNAGE INSTANCE) 25) (SAVE INSTANCE)))
```