### PR TITLE
execute migration

### DIFF
--- a/src/migration.lisp
+++ b/src/migration.lisp
@@ -130,11 +130,7 @@ table `table-name`."
                                   table-name
                                   internal-constraint))
                              (getf def :internal))
-                     (mapcar #'(lambda (external-constraint)
-                                 (crane.sql:add-constraint
-                                  table-name
-                                  external-constraint))
-                             (getf def :external)))))))
+                     (getf def :external))))))
          (deletions
            (mapcar #'(lambda (column-name)
                        (crane.sql:drop-column table-name

--- a/src/migration.lisp
+++ b/src/migration.lisp
@@ -142,9 +142,9 @@ table `table-name`."
                    (getf diff :deletions)))
 	 (conn (crane.connect:get-connection (crane.meta:table-database
                                               (find-class table-name)))))
-    (dbi:execute (dbi:prepare conn
-			      (reduce #'(lambda (a b) (concatenate 'string a ";" b))
-				      (append alterations additions deletions))))))
+    (dolist (query (append alterations additions deletions))
+      (format t "~&Query: ~A~&" query)
+      (dbi:execute (dbi:prepare conn query)))))
 
 (defun build (table-name)
   (unless (crane.meta:abstractp (find-class table-name))

--- a/src/migration.lisp
+++ b/src/migration.lisp
@@ -139,9 +139,12 @@ table `table-name`."
            (mapcar #'(lambda (column-name)
                        (crane.sql:drop-column table-name
                                               column-name))
-                   (getf diff :deletions))))
-    (reduce #'(lambda (a b) (concatenate 'string a ";" b))
-            (append alterations additions deletions))))
+                   (getf diff :deletions)))
+	 (conn (crane.connect:get-connection (crane.meta:table-database
+                                              (find-class table-name)))))
+    (dbi:execute (dbi:prepare conn
+			      (reduce #'(lambda (a b) (concatenate 'string a ";" b))
+				      (append alterations additions deletions))))))
 
 (defun build (table-name)
   (unless (crane.meta:abstractp (find-class table-name))

--- a/src/sql.lisp
+++ b/src/sql.lisp
@@ -192,9 +192,9 @@ database it's table belongs to"
                            column-name
                            type))
       ;; NULL constraint
-      (if value
+      (if (null value)
           ;; Set null
-          (aif (make-constraint table-name column-name :nullp t)
+          (aif (make-constraint table-name column-name :nullp nil)
                (add-constraint table-name it))
           ;; Remove null constraint
           (drop-constraint table-name


### PR DESCRIPTION
As I indicated in issue #35, migrations are not taking place for me.  It appeared to me that the alter table statement was never being executed.  This modification to execute the statement appears to work for me.