### PR TITLE
Fix duplicate definition error

### DIFF
--- a/src/inflate-deflate.lisp
+++ b/src/inflate-deflate.lisp
@@ -38,7 +38,6 @@ represent time, or mapping other more complex SQL types to CLOS objects."))
 (definflate (obj 'double) obj)
 (definflate (obj 'text) obj)
 (definflate (obj 'varchar) obj)
-(definflate (obj 'timestamp) obj)
 (definflate (obj 'datetime) obj)
 
 (definflate (stamp 'timestamp)


### PR DESCRIPTION
The duplicate definition of ```(definflate (stamp 'timestamp))``` causes a compiler error and prevents building a standalone app.