### PR TITLE
deftable: use &body for slots-and-options

### DIFF
--- a/src/table.lisp
+++ b/src/table.lisp
@@ -62,7 +62,7 @@ symbols, table options are keywords."
                  (crane.meta:abstractp (find-class class-name)))
              superclasses))
 
-(defmacro deftable (name (&rest superclasses) &rest slots-and-options)
+(defmacro deftable (name (&rest superclasses) &body slots-and-options)
   "Define a table."
   (destructuring-bind (slots options)
       (separate-slots-and-options slots-and-options)


### PR DESCRIPTION
Hi, this is so that slime can indent the macro properly
