### PR TITLE
loop over external constraints

### DIFF
--- a/src/migration.lisp
+++ b/src/migration.lisp
@@ -93,11 +93,13 @@ table `table-name`."
                    (getf constraints :definition)
                    (if (getf constraints :internal) "," "")
                    (getf constraints :internal)
-                   (getf constraints :external)))
+                   '()))
          (conn (crane.connect:get-connection (crane.meta:table-database
                                               (find-class table-name)))))
     (format t "~&Query: ~A~&" query)
-    (dbi:execute (dbi:prepare conn query))))
+    (dbi:execute (dbi:prepare conn query))
+    (loop for external-constraint in (getf constraints :external)
+          do (dbi:execute (dbi:prepare conn external-constraint)))))
 
 (defun migrate (table-class diff)
   (let* ((table-name (crane.meta:table-name table-class))


### PR DESCRIPTION
the postgres driver will blow up when you try and prepare a statement with two statements in it 
i.e.
  if you have an index on a column, it will try to do a 

``` sql
create table foo(id primary key, bar integer) ; create index blah on foo(bar)
```

I changed this to just loop over the external constraints.

I can write tests or w/e but this lets me keep using this.

cc @eudoxia0 
