### PR TITLE
Sqlite migrations fixed

### DIFF
--- a/src/connect.lisp
+++ b/src/connect.lisp
@@ -11,6 +11,7 @@
            :*default-db*
            :connect
            :disconnect
+	   :disconnect-clean
            :get-db
            :get-connection)
   (:documentation "Handles database connections, connection parameter validation, and various low-level DB-specific modes."))
@@ -89,7 +90,10 @@ the connection spec of the database '~A'" key db))))
 spec for the database '~A' have not been provided: ~A" db it))
          final-spec)))
 
-(defparameter *db* (make-hash-table)
+(defun initialize-*db* ()
+  (make-hash-table))
+
+(defparameter *db* (initialize-*db*)
   "A map from database names to <database> objects.")
 
 (defclass <database> ()
@@ -158,6 +162,11 @@ instances, and setting the value of *default-db*."
   "Cut all connections."
   (loop for db being the hash-values in *db* do
     (dbi:disconnect (database-connection db))))
+
+(defun disconnect-clean ()
+  "Cut all connections and reset *db* hashtable"
+  (disconnect)
+  (setf *db* (initialize-*db*)))
 
 (defun get-db (&optional database-name)
   "Return the database matching a specific name"

--- a/src/sql.lisp
+++ b/src/sql.lisp
@@ -77,7 +77,7 @@ behaviour of SxQL."
        it
        (error "No such referential action: ~A" action)))
 
-(defun foreign (local foreign-table &key (on-delete :no-action) (on-update :no-action))
+(defun foreign (local foreign-table &optional (on-delete :no-action) (on-update :no-action))
   (format nil "FOREIGN KEY (~A) REFERENCES ~A(id) ON DELETE ~A ON UPDATE ~A"
           (sqlize local)
           (sqlize foreign-table)

--- a/t/common/final.lisp
+++ b/t/common/final.lisp
@@ -1,6 +1,9 @@
 (in-package :crane-test)
 
 (run! 'crane-test.util:util-tests)
+
 (run! 'crane-test.spec:postgres)
+
 (run! 'crane-test.spec:mysql)
+
 (run! 'crane-test.spec:sqlite3)

--- a/t/postgres/final.lisp
+++ b/t/postgres/final.lisp
@@ -1,4 +1,7 @@
 (in-package :crane-test)
 
+(setf crane.connect::*db* (crane.connect::initialize-*db*))
+
 (run! 'preliminary)
+
 (run! 'crane-test.postgres:postgres)

--- a/t/postgres/table.lisp
+++ b/t/postgres/table.lisp
@@ -37,7 +37,7 @@
 
     (deftable child-table ()
       (something-else :type text :initform "Foo")
-      (ref :type integer :foreign (parent-table :on-delete :cascade)))))
+      (ref :type integer :foreign (parent-table :cascade :cascade)))))
 
 (test (dereferencing :depends-on creating-related-tables)
   (is (equal

--- a/t/sqlite3/final.lisp
+++ b/t/sqlite3/final.lisp
@@ -1,4 +1,7 @@
 (in-package :crane-test)
 
+(setf crane.connect::*db* (crane.connect::initialize-*db*))
+
 (run! 'preliminary)
+
 (run! 'crane-test.sqlite3:sqlite3)

--- a/t/sqlite3/inflate-deflate.lisp
+++ b/t/sqlite3/inflate-deflate.lisp
@@ -7,10 +7,13 @@
 
 (test (queries :depends-on create-table)
   (is-true
-   (let* ((timestamp (local-time:today))
+   (let* ((the-timestamp (local-time:today))
           (instance (create 'sq-table-with-time
-                            :field timestamp))
+                            :field the-timestamp))
           (found-instance
-            (single 'sq-table-with-time :field timestamp)))
-     (local-time:timestamp= timestamp
+	   (single 'sq-table-with-time
+		   :field
+		   (crane.inflate-deflate:deflate the-timestamp))))
+     (declare (ignore instance))
+     (local-time:timestamp= the-timestamp
                             (field found-instance)))))

--- a/t/sqlite3/table.lisp
+++ b/t/sqlite3/table.lisp
@@ -15,7 +15,7 @@
 
     (deftable sq-child-table ()
       (something-else :type text :initform "Foo")
-      (ref :type integer :foreign (sq-parent-table :on-delete :cascade)))))
+      (ref :type integer :foreign (sq-parent-table :cascade :cascade)))))
 
 (test (dereferencing :depends-on creating-related-tables)
   (is (equal


### PR DESCRIPTION
Hello, 

i was unable to use crane with sqlilte, during ~~migration~~ database creation the library complains about an "alter table" which is not supported.

The following patch try to fix that, it worked for me but i am unsure if this is a general solution (sorry for that, but i can not tests with other dbms).

Bye!
C.

PS: i found the unit test failed: fixed some; i will try to address the others ASAP.

PPS: Looks like all tests passed! :)
